### PR TITLE
fix: skip secondary requirements in scs_tested

### DIFF
--- a/src/rule-transform/rule-content/frontmatter/__tests__/get-rule-meta.ts
+++ b/src/rule-transform/rule-content/frontmatter/__tests__/get-rule-meta.ts
@@ -45,4 +45,35 @@ describe("getRuleMeta", () => {
       last_modified: moment().format("D MMMM YYYY"),
     });
   });
+
+  it("skips secondary requirements in scs_tested", () => {
+    const fm = {
+      ...frontmatter,
+      accessibility_requirements: {
+        "wcag21:1.4.3": sc214Requirement,
+        "wcag21:2.4.6": {
+          ...sc214Requirement,
+          secondary: true,
+        },
+      },
+    };
+    const ruleMeta = getRuleMeta(fm);
+    const frontmatterData = stripDashes(ruleMeta);
+    const data = yaml.load(frontmatterData);
+
+    expect(data).toEqual({
+      id: "abc123",
+      name: "hello world",
+      description: "Some description\n",
+      rule_type: "atomic",
+      scs_tested: [
+        {
+          num: "1.4.3",
+          handle: "Contrast (Minimum)",
+          level: "AA",
+        },
+      ],
+      last_modified: moment().format("D MMMM YYYY"),
+    });
+  });
 });

--- a/src/rule-transform/rule-content/frontmatter/get-rule-meta.ts
+++ b/src/rule-transform/rule-content/frontmatter/get-rule-meta.ts
@@ -22,10 +22,12 @@ function getSCsTested(
   const accRequirements = Object.entries(accessibility_requirements);
   let criterionCount = 0;
   let text = "scs_tested:";
-  accRequirements.forEach(([requirementId]) => {
+  accRequirements.forEach(([requirementId, req]) => {
     const [requirementDoc, scNumber] = requirementId.split(":");
     const criterion = criteria[scNumber];
-    if (!requirementDoc.includes("wcag2") || !criterion) return;
+    if (!requirementDoc.includes("wcag2") || !criterion || req.secondary) {
+      return;
+    }
 
     criterionCount++;
     text += `\n  - handle: ${criterion.handle}`;


### PR DESCRIPTION
Remove secondary requirements from the list of SCs the rule tests.