### PR TITLE
Accept mappings from `cantTell` outcomes

### DIFF
--- a/src/map-implementation/__test-utils__.ts
+++ b/src/map-implementation/__test-utils__.ts
@@ -80,7 +80,7 @@ export function getTestData(input: Partial<TestData> = {}): TestData {
     procedureName,
     accessibilityRequirements: failedRequirements,
   };
-  const outcomes = [expected];
+  const outcomes = input.outcomes ?? [expected];
   const automatic = true;
   const testResult: TestResult = {
     testcaseId,

--- a/src/map-implementation/get-act-implementation-report.ts
+++ b/src/map-implementation/get-act-implementation-report.ts
@@ -21,7 +21,6 @@ export async function getActImplementationReport(
   const proposedRules = emptyRuleStats();
 
   const actAssertions = await earlToActAssertions(earlReport);
-  console.log(`Found ${actAssertions.length} assertions`);
 
   const actRuleMapping: ActProcedureSet[] = [];
   for (const ruleGroup of groupByRule(testCases, actAssertions)) {

--- a/src/map-implementation/procedures/__tests__/get-rule-procedure-mapping.test.ts
+++ b/src/map-implementation/procedures/__tests__/get-rule-procedure-mapping.test.ts
@@ -88,4 +88,19 @@ describe("getRuleProcedureMapping", () => {
     const mapping = getRuleProcedureMapping([testCase], [actAssertion])[0];
     expect(mapping.failedRequirements).toEqual(failedRequirements);
   });
+
+  it("reports failed requirements from cantTell outcomes", () => {
+    const { testCase, actAssertion, procedureName, failedRequirements } =
+      getTestData({ outcomes: ["cantTell"] });
+    const assertion: ActAssertion = { ...actAssertion, outcome: "cantTell" };
+    const mappings = getRuleProcedureMapping([testCase], [assertion]);
+    const testResult = getTestResult(testCase, [assertion]);
+    expect(mappings).toEqual([
+      {
+        procedureName,
+        failedRequirements,
+        testResults: [testResult],
+      },
+    ]);
+  });
 });

--- a/src/map-implementation/procedures/__tests__/get-rule-procedure-mapping.test.ts
+++ b/src/map-implementation/procedures/__tests__/get-rule-procedure-mapping.test.ts
@@ -91,7 +91,7 @@ describe("getRuleProcedureMapping", () => {
 
   it("reports failed requirements from cantTell outcomes", () => {
     const { testCase, actAssertion, procedureName, failedRequirements } =
-      getTestData({ outcomes: ["cantTell"] });
+      getTestData();
     const assertion: ActAssertion = { ...actAssertion, outcome: "cantTell" };
     const mappings = getRuleProcedureMapping([testCase], [assertion]);
     const testResult = getTestResult(testCase, [assertion]);

--- a/src/map-implementation/procedures/get-rule-procedure-mapping.ts
+++ b/src/map-implementation/procedures/get-rule-procedure-mapping.ts
@@ -56,7 +56,10 @@ export function groupAssertionsByProcedure(
 export function getFailedRequirements(actAssertions: ActAssertion[]): string[] {
   const failedRequirements: string[] = [];
   for (const actAssertion of actAssertions) {
-    if (actAssertion.outcome === "failed") {
+    if (
+      actAssertion.outcome === "failed" ||
+      actAssertion.outcome === "cantTell"
+    ) {
       actAssertion.accessibilityRequirements?.forEach((requirement) => {
         if (!failedRequirements.includes(requirement)) {
           failedRequirements.push(requirement);


### PR DESCRIPTION
Running this on Alfa report does change the correctness of `accessibilityRequirements` for SIA-R15, SIA-R41, and SIA-R81 🎉 