### PR TITLE
feat: use deprecation info in WAI website

### DIFF
--- a/src/build-examples/__tests__/update-test-cases-json.test.ts
+++ b/src/build-examples/__tests__/update-test-cases-json.test.ts
@@ -115,5 +115,37 @@ describe("build-examples", () => {
       expect(filteredTestCases).toHaveLength(1);
       expect(filteredTestCases[0]).toEqual(approvedRule);
     });
+
+    it("skips tests from deprecated rules", async () => {
+      const { testcases } = await updateTestCaseJson(
+        jsonPath,
+        baseUrl,
+        testCaseData.map((testCase) => ({
+          ...testCase,
+          deprecated: true,
+        }))
+      );
+      expect(testcases).toHaveLength(1);
+    });
+
+    it("removes tests from deprecated approved rules", async () => {
+      testCaseData = [
+        {
+          ...testCaseData[0],
+          deprecated: true,
+          metadata: {
+            ...testCaseData[0].metadata,
+            ruleId: "abc123",
+            testcaseId: "261dcd3214e87532fc2f9c8db7fdce05de9e07f0",
+          },
+        },
+      ];
+      const { testcases } = await updateTestCaseJson(
+        jsonPath,
+        baseUrl,
+        testCaseData
+      );
+      expect(testcases).toHaveLength(0);
+    });
   });
 });

--- a/src/build-examples/extract-test-cases.ts
+++ b/src/build-examples/extract-test-cases.ts
@@ -4,6 +4,7 @@ import { TestCase, RulePage } from "../types";
 export type TestCaseData = {
   codeSnippet: string;
   filePath: string;
+  deprecated?: boolean;
   metadata: TestCase;
 };
 
@@ -18,6 +19,7 @@ export function extractTestCases(
     name: ruleName,
     accessibility_requirements: ruleAccessibilityRequirements,
   } = frontmatter;
+  const deprecated = typeof frontmatter.deprecated === "string";
 
   const ruleData = {
     ruleId,
@@ -38,7 +40,7 @@ export function extractTestCases(
         url: baseUrl + filePath,
         rulePage: pageUrl + ruleId + (proposed ? `/proposed/` : `/`),
       };
-      return { codeSnippet, filePath, metadata };
+      return { codeSnippet, filePath, deprecated, metadata };
     }
   );
 }

--- a/src/build-examples/update-test-case-json.ts
+++ b/src/build-examples/update-test-case-json.ts
@@ -26,14 +26,16 @@ export async function updateTestCaseJson(
     };
   }
 
-  testCaseData.forEach(({ metadata: testcase }) => {
-    const isExistingTestCase = testCasesJson.testcases.some(
+  testCaseData.forEach(({ metadata: testcase, deprecated }) => {
+    const currentIndex = testCasesJson.testcases.findIndex(
       ({ testcaseId, ruleId }) =>
         testcaseId === testcase.testcaseId && ruleId === testcase.ruleId
     );
 
-    if (!isExistingTestCase) {
+    if (currentIndex === -1 && !deprecated) {
       testCasesJson.testcases.push(testcase);
+    } else if (currentIndex !== -1 && deprecated) {
+      testCasesJson.testcases.splice(currentIndex, 1);
     }
   });
 

--- a/src/rule-transform/__tests__/create-wcag-mapping.ts
+++ b/src/rule-transform/__tests__/create-wcag-mapping.ts
@@ -9,6 +9,12 @@ import { createWcagMapping } from "../create-wcag-mapping";
 const mkdir = promisify(fs.mkdir);
 const rm = promisify(fs.rm);
 const tmpDir = "./.tmp";
+const mappingBase = {
+  successCriteria: [],
+  wcagTechniques: [],
+  proposed: false,
+  deprecated: false,
+};
 
 function getRulePage(metadata = ""): RulePage {
   const page = parsePage(outdent`
@@ -44,11 +50,9 @@ describe("rule-transform", () => {
       expect(mapping).toEqual({
         "act-rules": [
           {
+            ...mappingBase,
             title: "Hello world",
             permalink: "/standards-guidelines/act/rules/123abc/",
-            successCriteria: [],
-            wcagTechniques: [],
-            proposed: false,
           },
         ],
       });
@@ -69,10 +73,10 @@ describe("rule-transform", () => {
       expect(mapping).toEqual({
         "act-rules": [
           {
+            ...mappingBase,
             title: "Hello world",
             permalink: "/standards-guidelines/act/rules/123abc/proposed/",
             successCriteria: ["non-text-content", "language-of-page"],
-            wcagTechniques: [],
             proposed: true,
           },
         ],
@@ -96,6 +100,7 @@ describe("rule-transform", () => {
       expect(mapping).toEqual({
         "act-rules": [
           {
+            ...mappingBase,
             title: "Hello world",
             permalink: "/standards-guidelines/act/rules/123abc/proposed/",
             successCriteria: ["non-text-content"],
@@ -116,10 +121,9 @@ describe("rule-transform", () => {
       expect(mapping).toEqual({
         "act-rules": [
           {
+            ...mappingBase,
             title: "Hello world",
             permalink: "/standards-guidelines/act/rules/123abc/proposed/",
-            successCriteria: [],
-            wcagTechniques: [],
             proposed: true,
           },
         ],
@@ -133,11 +137,9 @@ describe("rule-transform", () => {
         JSON.stringify({
           "act-rules": [
             {
+              ...mappingBase,
               title: "Hello Mars",
               permalink: "/standards-guidelines/act/rules/789xyz/",
-              successCriteria: [],
-              wcagTechniques: [],
-              proposed: false,
             },
           ],
         })
@@ -149,18 +151,14 @@ describe("rule-transform", () => {
       expect(mapping).toEqual({
         "act-rules": [
           {
+            ...mappingBase,
             title: "Hello Mars",
             permalink: "/standards-guidelines/act/rules/789xyz/",
-            successCriteria: [],
-            wcagTechniques: [],
-            proposed: false,
           },
           {
+            ...mappingBase,
             title: "Hello world",
             permalink: "/standards-guidelines/act/rules/123abc/",
-            successCriteria: [],
-            wcagTechniques: [],
-            proposed: false,
           },
         ],
       });
@@ -173,11 +171,9 @@ describe("rule-transform", () => {
         JSON.stringify({
           "act-rules": [
             {
+              ...mappingBase,
               title: "Hello Mars",
               permalink: "/standards-guidelines/act/rules/123abc/",
-              successCriteria: [],
-              wcagTechniques: [],
-              proposed: false,
             },
           ],
         })
@@ -189,11 +185,9 @@ describe("rule-transform", () => {
       expect(mapping).toEqual({
         "act-rules": [
           {
+            ...mappingBase,
             title: "Hello world",
             permalink: "/standards-guidelines/act/rules/123abc/",
-            successCriteria: [],
-            wcagTechniques: [],
-            proposed: false,
           },
         ],
       });
@@ -212,11 +206,9 @@ describe("rule-transform", () => {
           content: {
             "act-rules": [
               {
+                ...mappingBase,
                 permalink: "/standards-guidelines/act/rules/123abc/",
-                proposed: false,
-                successCriteria: [],
                 title: "Hello world",
-                wcagTechniques: [],
               },
             ],
           },
@@ -231,11 +223,9 @@ describe("rule-transform", () => {
         JSON.stringify({
           "act-rules": [
             {
+              ...mappingBase,
               title: "Hello Mars",
               permalink: "/standards-guidelines/act/rules/123abc/",
-              successCriteria: [],
-              wcagTechniques: [],
-              proposed: false,
             },
           ],
         })
@@ -249,11 +239,28 @@ describe("rule-transform", () => {
       expect(mapping).toEqual({
         "act-rules": [
           {
+            ...mappingBase,
             title: "Hello world",
             permalink: "/standards-guidelines/act/rules/123abc/",
-            successCriteria: [],
-            wcagTechniques: [],
-            proposed: false,
+          },
+        ],
+      });
+    });
+
+    it("indicates when rules are deprecated", async () => {
+      const filePath = "./.tmp/wcag-mapping.json";
+      const rulePage = getRulePage();
+      rulePage.frontmatter.deprecated = "This rule is deprecated.";
+
+      createFile.mock();
+      const mapping = await createWcagMapping(filePath, [rulePage]);
+      expect(mapping).toEqual({
+        "act-rules": [
+          {
+            ...mappingBase,
+            title: "Hello world",
+            permalink: "/standards-guidelines/act/rules/123abc/",
+            deprecated: true,
           },
         ],
       });

--- a/src/rule-transform/create-wcag-mapping.ts
+++ b/src/rule-transform/create-wcag-mapping.ts
@@ -9,6 +9,7 @@ export type ActWcagMap = {
   successCriteria: string[];
   wcagTechniques: string[];
   proposed?: boolean;
+  deprecated?: boolean;
 };
 
 export type WcagMapping = {
@@ -43,7 +44,7 @@ export function updateWcagMapping(
   { frontmatter }: RulePage,
   { proposed }: { proposed: boolean }
 ): ActWcagMap[] {
-  const { id } = frontmatter;
+  const { id, deprecated } = frontmatter;
   const currentItem = wcagMapping.findIndex(({ permalink }) =>
     permalink.includes(`/${id}`)
   );
@@ -54,10 +55,11 @@ export function updateWcagMapping(
 
   const { successCriteria, wcagTechniques } = getRequirements(frontmatter);
   wcagMapping.push({
-    title: frontmatter.name.replace(/`/gi, ""),
+    title: frontmatter.name.replace(/`/gi, "").replace("DEPRECATED - ", ""),
     permalink: ruleUrl(frontmatter.id, proposed),
     successCriteria,
     wcagTechniques,
+    deprecated: typeof deprecated === "string",
     proposed,
   });
   return wcagMapping;

--- a/src/rule-transform/rule-content/__tests__/get-frontmatter.ts
+++ b/src/rule-transform/rule-content/__tests__/get-frontmatter.ts
@@ -80,5 +80,33 @@ describe("rule-content", () => {
         "*Hello* world, welcome to ACT_taskforce **"
       );
     });
+
+    it("optionally includes deprecated text", () => {
+      const deprecated = "This rule\nhas been\ndeprecated";
+      const deprecatedRuleData = {
+        ...ruleData,
+        frontmatter: { ...ruleData.frontmatter, deprecated },
+      };
+
+      const frontmatterStr = getFrontmatter(deprecatedRuleData);
+      const frontmatterData = stripDashes(frontmatterStr);
+      const data = yaml.load(frontmatterData) as any;
+      expect(data.deprecated.trim()).toBe(deprecated);
+    });
+
+    it('strips "DEPRECATED - " from titles', () => {
+      const deprecatedRuleData = {
+        ...ruleData,
+        frontmatter: {
+          ...ruleData.frontmatter,
+          name: `DEPRECATED - ${ruleData.frontmatter.name}`,
+        },
+      };
+
+      const frontmatterStr = getFrontmatter(deprecatedRuleData);
+      const frontmatterData = stripDashes(frontmatterStr);
+      const data = yaml.load(frontmatterData) as any;
+      expect(data.title).toBe(ruleData.frontmatter.name);
+    });
   });
 });

--- a/src/rule-transform/rule-content/get-frontmatter.ts
+++ b/src/rule-transform/rule-content/get-frontmatter.ts
@@ -18,9 +18,13 @@ export const getFrontmatter = (
     proposed ? "proposed" : "index"
   }.md`;
 
+  const deprecated = !frontmatter.deprecated
+    ? ""
+    : `deprecated: |\n${indent(frontmatter.deprecated)}\n`;
+
   return outdent`
     ---
-    title: "${stripMarkdownFromStr(frontmatter.name)}"
+    title: "${normalizeTitle(frontmatter.name)}"
     permalink: ${permalink}/
     ref: ${permalink}/
     lang: en
@@ -31,15 +35,16 @@ export const getFrontmatter = (
     footer: |
     ${indent(getFooter(frontmatter, options?.proposed))}
     proposed: ${options?.proposed || false}
+    ${deprecated}
     rule_meta:
     ${indent(getRuleMeta(frontmatter))}
     ---
-  `;
+  `.replace("\n\n", "\n");
 };
 
-function stripMarkdownFromStr(str: string): string {
+function normalizeTitle(str: string): string {
   const AST = parseMarkdown(str);
-  return stripMarkdownFromAST(AST);
+  return stripMarkdownFromAST(AST).replace("DEPRECATED -", "").trim();
 }
 
 function stripMarkdownFromAST(node: Node | Parent | Literal): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export type RuleFrontMatterBase = {
   name: string;
   rule_type: "atomic" | "composite";
   description: string;
+  deprecated?: string;
   accessibility_requirements?: Record<string, AccessibilityRequirement>;
   acknowledgments?: Record<string, string[]>;
 };


### PR DESCRIPTION
- Avoids adding proposed test cases of deprecated rules
- Remove deprecated test cases from approved rules
- Include deprecated info in the WAI rule page frontmatter
- Strip "DEPRECATED -"out of the rule titles
- Update wcag-mapping.json mapping