### PR TITLE
fix(example): don't double-wrap head and body elements

### DIFF
--- a/src/act/examples/__tests__/add-code-template.ts
+++ b/src/act/examples/__tests__/add-code-template.ts
@@ -52,6 +52,57 @@ describe("build-examples", () => {
       `);
     });
 
+    it("wraps <head> elements with <html>", () => {
+      const headCode = outdent`
+        <head>
+        \t<title>Hello world</title>
+        </head>
+      `;
+      const snippet = addCodeTemplate(headCode, "html", "foo");
+      expect(snippet).toBe(outdent`
+        <!DOCTYPE html>
+        <html lang="en">
+        ${headCode}
+        </html>
+      `);
+    });
+
+    it("wraps <body> elements with <html>", () => {
+      const bodyCode = outdent`
+        <body>
+        \t<p>Hello</p>
+        </body>
+      `;
+      const snippet = addCodeTemplate(bodyCode, "html", "foo");
+      expect(snippet).toBe(outdent`
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+        \t<title>foo</title>
+        </head>
+        ${bodyCode}
+        </html>
+      `);
+    });
+
+    it("wraps <head> and <body> elements with <html>", () => {
+      const innerHtmlCode = outdent`
+        <head>
+        \t<title>Hello world</title>
+        </head>
+        <body>
+        \t<p>Hello</p>
+        </body>
+      `;
+      const snippet = addCodeTemplate(innerHtmlCode, "html", "foo");
+      expect(snippet).toBe(outdent`
+        <!DOCTYPE html>
+        <html lang="en">
+        ${innerHtmlCode}
+        </html>
+      `);
+    });
+
     it("adds an XHTML 1.1 doctype to XHTML documents", () => {
       const snippet = addCodeTemplate(
         `<html>\n${code}\n</html>`,

--- a/src/act/examples/add-code-template.ts
+++ b/src/act/examples/add-code-template.ts
@@ -38,15 +38,37 @@ export const htmlTemplate = (
   title: string,
   code: string
 ): string => {
+  const strings = [
+    doctype,
+    '<html lang="en">',
+    headTemplate(title, code),
+    bodyTemplate(code),
+    "</html>",
+  ];
+  return strings.filter((str) => str !== "").join("\n");
+};
+
+export const headTemplate = (title: string, code: string): string => {
+  if (/<head/i.test(code)) {
+    return code;
+  }
   return outdent`
-    ${doctype}
-    <html lang="en">
     <head>
     \t<title>${title}</title>
     </head>
+  `;
+};
+
+export const bodyTemplate = (code: string): string => {
+  if (/<head/i.test(code)) {
+    return "";
+  }
+  if (/<body/i.test(code)) {
+    return code;
+  }
+  return outdent`
     <body>
     ${indent(code, "\t", 1)}
     </body>
-    </html>
   `;
 };


### PR DESCRIPTION
We had a problem with some of the test case files, where if they had just `<head>` without an HTML element the code would be placed inside the body. This should solve that, and allow the same to work with `<body>` if we ever need that.

Closes #13 