### PR TITLE
fix(map-implementation): remove minimal consistency mapping

### DIFF
--- a/src/map-implementation/__tests__/get-act-implementation-report.test.ts
+++ b/src/map-implementation/__tests__/get-act-implementation-report.test.ts
@@ -69,7 +69,6 @@ describe("getActImplementationReport", () => {
     expect(approvedRules).toEqual({
       complete: 1,
       partial: 0,
-      minimal: 0,
       inconsistent: 0,
       untested: 0,
     });
@@ -80,7 +79,6 @@ describe("getActImplementationReport", () => {
     expect(proposedRules).toEqual({
       complete: 0,
       partial: 0,
-      minimal: 0,
       inconsistent: 0,
       untested: 0,
     });

--- a/src/map-implementation/get-act-implementation-report.ts
+++ b/src/map-implementation/get-act-implementation-report.ts
@@ -132,7 +132,6 @@ function emptyRuleStats(): RuleStats {
   return {
     complete: 0,
     partial: 0,
-    minimal: 0,
     inconsistent: 0,
     untested: 0,
   };

--- a/src/map-implementation/procedure-sets/__tests__/find-procedure-set.test.ts
+++ b/src/map-implementation/procedure-sets/__tests__/find-procedure-set.test.ts
@@ -56,7 +56,7 @@ describe("findProcedureSet", () => {
     failedRequirements: ["WCAG2:foo"],
     testResults: [correctPass, correctFail],
   };
-  const minimalProcedure: ActProcedureMapping = {
+  const cantTellOnlyProcedure: ActProcedureMapping = {
     ...procedureDefaults,
     testResults: [cantTellPass, correctInapplicable],
   };
@@ -83,37 +83,41 @@ describe("findProcedureSet", () => {
     );
   });
 
-  it("reports minimal over inconsistent", () => {
+  it("reports partially consistent (cantTell only) over inconsistent", () => {
     const procedureSet = findProcedureSet([
-      minimalProcedure,
-      inconsistentProcedure,
-    ]);
-    expect(procedureSet).toHaveProperty("consistency", "minimal");
-    expect(procedureSet.testCaseResults).toEqual(
-      getTestCaseResults([minimalProcedure])
-    );
-  });
-
-  it("reports partial over minimal or inconsistent", () => {
-    const procedureSet = findProcedureSet([
-      partialProcedure1,
-      partialProcedure2,
-      minimalProcedure,
+      cantTellOnlyProcedure,
       inconsistentProcedure,
     ]);
     expect(procedureSet).toHaveProperty("consistency", "partial");
     expect(procedureSet.testCaseResults).toEqual(
-      getTestCaseResults([partialProcedure1, partialProcedure2])
+      getTestCaseResults([cantTellOnlyProcedure])
     );
   });
 
-  it("reports complete consistency over partial, minimal or inconsistent", () => {
+  it("reports both partial with failed, and partial due to canTells over inconsistent", () => {
+    const procedureSet = findProcedureSet([
+      partialProcedure1,
+      partialProcedure2,
+      cantTellOnlyProcedure,
+      inconsistentProcedure,
+    ]);
+    expect(procedureSet).toHaveProperty("consistency", "partial");
+    expect(procedureSet.testCaseResults).toEqual(
+      getTestCaseResults([
+        partialProcedure1,
+        partialProcedure2,
+        cantTellOnlyProcedure,
+      ])
+    );
+  });
+
+  it("reports complete consistency over partial, or inconsistent", () => {
     const procedureSet = findProcedureSet([
       completeProcedure1,
       completeProcedure2,
       partialProcedure1,
       partialProcedure2,
-      minimalProcedure,
+      cantTellOnlyProcedure,
       inconsistentProcedure,
     ]);
     expect(procedureSet).toHaveProperty("consistency", "complete");

--- a/src/map-implementation/procedure-sets/__tests__/get-consistency.test.ts
+++ b/src/map-implementation/procedure-sets/__tests__/get-consistency.test.ts
@@ -257,46 +257,46 @@ describe("getConsistency", () => {
         })
       ).toBe("partial");
     });
-  });
 
-  describe("minimal consistency", () => {
-    it("is minimal when passed has a cantTell, and no true positives", () => {
-      expect(
-        getConsistency({
-          ...procedureDefaults,
-          testResults: toTestResults([
-            { expected: "passed", outcomes: ["cantTell"] },
-            { expected: "failed", outcomes: ["passed"] },
-            { expected: "inapplicable", outcomes: ["inapplicable"] },
-          ]),
-        })
-      ).toBe("minimal");
-    });
+    describe("with only cantTell outcomes", () => {
+      it("is partial when passed has a cantTell, and no true positives", () => {
+        expect(
+          getConsistency({
+            ...procedureDefaults,
+            testResults: toTestResults([
+              { expected: "passed", outcomes: ["cantTell"] },
+              { expected: "failed", outcomes: ["passed"] },
+              { expected: "inapplicable", outcomes: ["inapplicable"] },
+            ]),
+          })
+        ).toBe("partial");
+      });
 
-    it("is minimal when failed has a cantTell, and no true positives", () => {
-      expect(
-        getConsistency({
-          ...procedureDefaults,
-          testResults: toTestResults([
-            { expected: "passed", outcomes: ["passed"] },
-            { expected: "failed", outcomes: ["cantTell"] },
-            { expected: "inapplicable", outcomes: ["inapplicable"] },
-          ]),
-        })
-      ).toBe("minimal");
-    });
+      it("is partial when failed has a cantTell, and no true positives", () => {
+        expect(
+          getConsistency({
+            ...procedureDefaults,
+            testResults: toTestResults([
+              { expected: "passed", outcomes: ["passed"] },
+              { expected: "failed", outcomes: ["cantTell"] },
+              { expected: "inapplicable", outcomes: ["inapplicable"] },
+            ]),
+          })
+        ).toBe("partial");
+      });
 
-    it("is not minimal when inapplicable has a cantTell, and no true positives", () => {
-      expect(
-        getConsistency({
-          ...procedureDefaults,
-          testResults: toTestResults([
-            { expected: "passed", outcomes: ["passed"] },
-            { expected: "failed", outcomes: ["cantTell"] },
-            { expected: "inapplicable", outcomes: ["cantTell"] },
-          ]),
-        })
-      ).toBeNull();
+      it("is not partial when inapplicable has a cantTell, and no true positives", () => {
+        expect(
+          getConsistency({
+            ...procedureDefaults,
+            testResults: toTestResults([
+              { expected: "passed", outcomes: ["passed"] },
+              { expected: "failed", outcomes: ["cantTell"] },
+              { expected: "inapplicable", outcomes: ["cantTell"] },
+            ]),
+          })
+        ).toBeNull();
+      });
     });
   });
 });

--- a/src/map-implementation/procedure-sets/find-procedure-set.ts
+++ b/src/map-implementation/procedure-sets/find-procedure-set.ts
@@ -84,12 +84,7 @@ function getProcedureScore(
   return { consistency, coverage, mapping };
 }
 
-const consistencyLevels: ConsistencyLevel[] = [
-  "complete",
-  "partial",
-  "minimal",
-  null,
-];
+const consistencyLevels: ConsistencyLevel[] = ["complete", "partial", null];
 
 function findConsistency(
   consistencyA: ConsistencyLevel,

--- a/src/map-implementation/procedure-sets/get-consistency.ts
+++ b/src/map-implementation/procedure-sets/get-consistency.ts
@@ -33,7 +33,7 @@ export function getConsistency(
     return "partial";
   }
   if (hasCantTell(testResults) && inapplicableAllTruePositive(testResults)) {
-    return "minimal";
+    return "partial";
   }
   return null;
 }

--- a/src/map-implementation/types.ts
+++ b/src/map-implementation/types.ts
@@ -9,7 +9,7 @@ export {
   AccessibilityRequirement,
 } from "../types";
 
-export type ConsistencyTypes = "complete" | "partial" | "minimal";
+export type ConsistencyTypes = "complete" | "partial";
 
 export type ConsistencyLevel = ConsistencyTypes | null;
 


### PR DESCRIPTION
This stops the implementation mapper from reporting minimally consistent rules, and reports those as partial now. This solves a problem IBM was having where a combination of a minimal and a partial rule was not considered consistent, because combining was only ever attempted when both rules are partially consistent.