### PR TITLE
feat: add original_file for linking to github edit

### DIFF
--- a/src/rule-transform/__tests__/get-rule-content.ts
+++ b/src/rule-transform/__tests__/get-rule-content.ts
@@ -81,6 +81,7 @@ describe("getRuleContent", () => {
         id: abc123
         name: "Hello world"
         rule_type: atomic
+        original_file: abc123.md
         description: |
           hello world
         last_modified: ${moment().format("D MMMM YYYY")}

--- a/src/rule-transform/rule-content/__tests__/get-frontmatter.ts
+++ b/src/rule-transform/rule-content/__tests__/get-frontmatter.ts
@@ -63,7 +63,9 @@ describe("rule-content", () => {
         },
         footer: getFooter(ruleData.frontmatter, true) + "\n",
         proposed: true,
-        rule_meta: yaml.load(getRuleMeta(ruleData.frontmatter)),
+        rule_meta: yaml.load(
+          getRuleMeta(ruleData.frontmatter, ruleData.filename)
+        ),
       });
     });
 
@@ -71,6 +73,7 @@ describe("rule-content", () => {
       const name = "`*Hello*` **world, welcome** to _ACT_taskforce_ **";
       const frontmatterStr = getFrontmatter({
         frontmatter: { ...frontmatter, name },
+        filename: ruleData.filename,
       });
       const frontmatterData = stripDashes(frontmatterStr);
       const data = yaml.load(frontmatterData);

--- a/src/rule-transform/rule-content/frontmatter/__tests__/get-rule-meta.ts
+++ b/src/rule-transform/rule-content/frontmatter/__tests__/get-rule-meta.ts
@@ -8,6 +8,7 @@ function stripDashes(str: string): string {
 }
 
 describe("getRuleMeta", () => {
+  const filename = "rule-abc123.md";
   const sc214Requirement = {
     forConformance: true,
     failed: "not satisfied",
@@ -26,7 +27,7 @@ describe("getRuleMeta", () => {
   };
 
   it("has the appropriate data in the yaml", () => {
-    const ruleMeta = getRuleMeta(frontmatter);
+    const ruleMeta = getRuleMeta(frontmatter, filename);
     const frontmatterData = stripDashes(ruleMeta);
     const data = yaml.load(frontmatterData);
 
@@ -35,6 +36,7 @@ describe("getRuleMeta", () => {
       name: "hello world",
       description: "Some description\n",
       rule_type: "atomic",
+      original_file: filename,
       scs_tested: [
         {
           num: "2.1.4",
@@ -57,7 +59,7 @@ describe("getRuleMeta", () => {
         },
       },
     };
-    const ruleMeta = getRuleMeta(fm);
+    const ruleMeta = getRuleMeta(fm, filename);
     const frontmatterData = stripDashes(ruleMeta);
     const data = yaml.load(frontmatterData);
 
@@ -66,6 +68,7 @@ describe("getRuleMeta", () => {
       name: "hello world",
       description: "Some description\n",
       rule_type: "atomic",
+      original_file: filename,
       scs_tested: [
         {
           num: "1.4.3",

--- a/src/rule-transform/rule-content/frontmatter/get-rule-meta.ts
+++ b/src/rule-transform/rule-content/frontmatter/get-rule-meta.ts
@@ -3,12 +3,16 @@ import moment from "moment";
 import { AccessibilityRequirement, RuleFrontMatter } from "../../../types";
 import { criteria } from "../../../data/index";
 
-export function getRuleMeta(frontmatter: RuleFrontMatter): string {
+export function getRuleMeta(
+  frontmatter: RuleFrontMatter,
+  fileName: string
+): string {
   const date = moment().format("D MMMM YYYY");
   return outdent`
     id: ${frontmatter.id}
     name: "${frontmatter.name}"
     rule_type: ${frontmatter.rule_type}
+    original_file: ${fileName}
     description: |
       ${frontmatter.description.trim()}
     last_modified: ${date}

--- a/src/rule-transform/rule-content/get-frontmatter.ts
+++ b/src/rule-transform/rule-content/get-frontmatter.ts
@@ -1,13 +1,13 @@
 import { Node, Parent, Literal } from "unist";
 import { outdent } from "outdent";
-import { RuleFrontMatter } from "../../types";
+import { RulePage } from "../../types";
 import { parseMarkdown } from "../../utils/parse-page";
 import { getFooter } from "./frontmatter/get-footer";
 import { getRuleMeta } from "./frontmatter/get-rule-meta";
 import { indent } from "../../utils/index";
 
 export const getFrontmatter = (
-  { frontmatter }: { frontmatter: RuleFrontMatter },
+  { frontmatter, filename }: Pick<RulePage, "frontmatter" | "filename">,
   _?: unknown,
   options?: Record<string, boolean | undefined>
 ): string => {
@@ -37,7 +37,7 @@ export const getFrontmatter = (
     proposed: ${options?.proposed || false}
     ${deprecated}
     rule_meta:
-    ${indent(getRuleMeta(frontmatter))}
+    ${indent(getRuleMeta(frontmatter, filename))}
     ---
   `.replace("\n\n", "\n");
 };


### PR DESCRIPTION
Adds a `rule_meta.original_file` so that we can do this:

https://github.com/w3c/wcag-act-rules/pull/200/files#diff-eb41111af58751cec2e9f1b07224daee7fa72e4ecbd01a4997d5f060538219d9R163

