### PR TITLE
Add possibility to link to ARIA in HTML

### DIFF
--- a/src/act/__tests__/get-accessibility-requirement.ts
+++ b/src/act/__tests__/get-accessibility-requirement.ts
@@ -29,16 +29,16 @@ describe("getAccessibilityRequirement", () => {
 
   it("returns ARIA requirements", () => {
     const ariaReq = getAccessibilityRequirement({
-      requirementId: "aria11:childrenArePresentational",
+      requirementId: "aria12:childrenArePresentational",
       title: "5.2.8 Presentational Children",
     });
 
     expect(ariaReq).toEqual({
-      conformanceLevel: "WAI-ARIA 1.1 author requirements",
+      conformanceLevel: "WAI-ARIA 1.2 author requirements",
       requirementType: "WAI-ARIA requirement",
       title: "5.2.8 Presentational Children",
       shortTitle: "5.2.8 Presentational Children",
-      url: "https://www.w3.org/TR/wai-aria-1.1/#childrenarepresentational",
+      url: "https://www.w3.org/TR/wai-aria-1.2/#childrenarepresentational",
     });
   });
 

--- a/src/act/__tests__/get-accessibility-requirement.ts
+++ b/src/act/__tests__/get-accessibility-requirement.ts
@@ -57,4 +57,22 @@ describe("getAccessibilityRequirement", () => {
       url: "https://www.w3.org/TR/using-aria/#fourth",
     });
   });
+
+  it("returns ARIA in HTML requirements", () => {
+    const fourth = getAccessibilityRequirement({
+      requirementId: "html-aria:docconformance",
+      title:
+        "ARIA in HTML, 4. Document conformance requirements for use of ARIA attributes in HTML",
+    });
+
+    expect(fourth).toEqual({
+      conformanceLevel: "ARIA in HTML",
+      requirementType: "ARIA in HTML requirement",
+      title:
+        "ARIA in HTML, 4. Document conformance requirements for use of ARIA attributes in HTML",
+      shortTitle:
+        "ARIA in HTML, 4. Document conformance requirements for use of ARIA attributes in HTML",
+      url: "https://www.w3.org/TR/html-aria/#docconformance",
+    });
+  });
 });

--- a/src/act/get-accessibility-requirement.ts
+++ b/src/act/get-accessibility-requirement.ts
@@ -10,9 +10,9 @@ type AccessibilityDocuments = {
 };
 
 const accessibilityDocs: AccessibilityDocuments = {
-  aria11: {
-    conformanceLevel: "WAI-ARIA 1.1 author requirements",
-    baseURL: "https://www.w3.org/TR/wai-aria-1.1/#",
+  aria12: {
+    conformanceLevel: "WAI-ARIA 1.2 author requirements",
+    baseURL: "https://www.w3.org/TR/wai-aria-1.2/#",
     requirementType: "WAI-ARIA requirement",
   },
   "dpub-aria": {

--- a/src/act/get-accessibility-requirement.ts
+++ b/src/act/get-accessibility-requirement.ts
@@ -26,6 +26,11 @@ const accessibilityDocs: AccessibilityDocuments = {
     baseURL: "https://www.w3.org/TR/graphics-aria-1.0/#",
     requirementType: "WAI-ARIA Graphics Module requirement",
   },
+  "html-aria": {
+    conformanceLevel: "ARIA in HTML",
+    baseURL: "https://www.w3.org/TR/html-aria/#",
+    requirementType: "ARIA in HTML requirement",
+  },
   "using-aria": {
     baseURL: "https://www.w3.org/TR/using-aria/#",
     requirementType: "WAI-ARIA rule",

--- a/src/act/get-accessibility-requirement.ts
+++ b/src/act/get-accessibility-requirement.ts
@@ -15,12 +15,14 @@ const accessibilityDocs: AccessibilityDocuments = {
     baseURL: "https://www.w3.org/TR/wai-aria-1.2/#",
     requirementType: "WAI-ARIA requirement",
   },
+  // Note: as of 28/09/2023, we have no rule mapping to DPUB ARIA
   "dpub-aria": {
     conformanceLevel:
       "WAI-ARIA Digital Publishing Module 1.0 author requirements",
     baseURL: "https://www.w3.org/TR/dpub-aria-1.0/#",
     requirementType: "WAI-ARIA Digital Publishing Module requirement",
   },
+  // Note: as of 28/09/2023, we have no rule mapping to Graphics ARIA
   "graphics-aria": {
     conformanceLevel: "WAI-ARIA Graphics Module 1.0 author requirements",
     baseURL: "https://www.w3.org/TR/graphics-aria-1.0/#",

--- a/src/rule-transform/__tests__/get-rule-content.ts
+++ b/src/rule-transform/__tests__/get-rule-content.ts
@@ -207,6 +207,28 @@ describe("getRuleContent", () => {
   it("accept all possible non-WCAG mappings", () => {
     const requirements = [
       {
+        source: `wcag-technique:ARIA5: # Using WAI-ARIA state and property attributes to expose the state of a user interface component
+          forConformance: false
+          failed: not satisfied
+          passed: further testing needed
+          inapplicable: further testing needed`,
+        expected: outdent`
+        <ul class="act-requirements-list">
+          <li><details>
+            <summary><span>ARIA5: Using WAI-ARIA state and property attributes to expose the state of a user interface component</span></summary>
+            <ul>
+              <li><a href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA5">Learn more about technique ARIA5</a></li>
+              <li>Not required for conformance to any W3C accessibility recommendation.</li>
+              <li>Outcome mapping: <ul>
+                <li>Any <code>failed</code> outcomes: technique is not satisfied</li>
+                <li>All <code>passed</code> outcomes: technique needs further testing</li>
+                <li>An <code>inapplicable</code> outcome: technique needs further testing</li>
+              </ul></li>
+            </ul>
+          </details></li>
+        </ul>`,
+      },
+      {
         source: `aria12:state_property_processing:
           title: ARIA 1.2, 8.6 State and Property Attribute Processing
           forConformance: true
@@ -228,20 +250,76 @@ describe("getRuleContent", () => {
             </ul>
           </details></li>
         </ul>`,
-        // {
-        //   source: `wcag-technique:ARIA5: # Using WAI-ARIA state and property attributes to expose the state of a user interface component
-        //     forConformance: false
-        //     failed: not satisfied
-        //     passed: further testing needed
-        //     inapplicable: further testing needed`,
-        //   expected: outdent``,
-        // },
       },
-      // { source: `dpub-aria:`, expected: outdent`` },
-      // { source: `graphics-aria`, expected: outdent`` },
-      // { source: `html-aria:`, expected: outdent`` },
-      // { source: `using-aria:`, expected: outdent`` },
-      // { source: `wcag-text:`, expected: outdent`` },
+      {
+        source: `html-aria:docconformance:
+          title: ARIA in HTML, 4. Document conformance requirements for use of ARIA attributes in HTML
+          forConformance: true
+          failed: not satisfied
+          passed: satisfied
+          inapplicable: satisfied`,
+        expected: outdent`
+        <ul class="act-requirements-list">
+          <li><details>
+            <summary><span>ARIA in HTML, 4. Document conformance requirements for use of ARIA attributes in HTML</span></summary>
+            <ul>
+              <li><a href="https://www.w3.org/TR/html-aria/#docconformance">Learn more about ARIA in HTML, 4. Document conformance requirements for use of ARIA attributes in HTML</a></li>
+              <li><strong>Required for conformance</strong> to ARIA in HTML.</li>
+              <li>Outcome mapping: <ul>
+                <li>Any <code>failed</code> outcomes: ARIA in HTML requirement is not satisfied</li>
+                <li>All <code>passed</code> outcomes: ARIA in HTML requirement is satisfied</li>
+                <li>An <code>inapplicable</code> outcome: ARIA in HTML requirement is satisfied</li>
+              </ul></li>
+            </ul>
+          </details></li>
+        </ul>`,
+      },
+      {
+        source: `using-aria:fourth:
+          title: Fourth rule of ARIA use
+          forConformance: false
+          failed: not satisfied
+          passed: further testing needed
+          inapplicable: further testing needed`,
+        expected: outdent`
+        <ul class="act-requirements-list">
+          <li><details>
+            <summary><span>Fourth rule of ARIA use</span></summary>
+            <ul>
+              <li><a href="https://www.w3.org/TR/using-aria/#fourth">Learn more about Fourth rule of ARIA use</a></li>
+              <li>Not required for conformance to any W3C accessibility recommendation.</li>
+              <li>Outcome mapping: <ul>
+                <li>Any <code>failed</code> outcomes: WAI-ARIA rule is not satisfied</li>
+                <li>All <code>passed</code> outcomes: WAI-ARIA rule needs further testing</li>
+                <li>An <code>inapplicable</code> outcome: WAI-ARIA rule needs further testing</li>
+              </ul></li>
+            </ul>
+          </details></li>
+        </ul>`,
+      },
+      {
+        source: `wcag-text:cc5: # Non-interference due to mapping to 2.2.2
+          title: WCAG Non-Interference
+          forConformance: true
+          failed: not satisfied
+          passed: further testing needed
+          inapplicable: further testing needed`,
+        expected: outdent`
+        <ul class="act-requirements-list">
+          <li><details>
+            <summary><span>WCAG Non-Interference</span></summary>
+            <ul>
+              <li><a href="https://www.w3.org/TR/WCAG21/#cc5">Learn more about WCAG Non-Interference</a></li>
+              <li><strong>Required for conformance</strong> to WCAG 2.1.</li>
+              <li>Outcome mapping: <ul>
+                <li>Any <code>failed</code> outcomes: WCAG 2 conformance requirement is not satisfied</li>
+                <li>All <code>passed</code> outcomes: WCAG 2 conformance requirement needs further testing</li>
+                <li>An <code>inapplicable</code> outcome: WCAG 2 conformance requirement needs further testing</li>
+              </ul></li>
+            </ul>
+          </details></li>
+        </ul>`,
+      },
     ];
 
     for (const requirement of requirements) {

--- a/src/rule-transform/__tests__/get-rule-content.ts
+++ b/src/rule-transform/__tests__/get-rule-content.ts
@@ -1,11 +1,11 @@
-import outdent from "outdent";
 import moment from "moment";
+import outdent from "outdent";
+import { RulePage } from "../../types";
+import { indent } from "../../utils/index";
 import { parsePage } from "../../utils/parse-page";
 import { createGlossary } from "../__test-utils";
 import { getRuleContent } from "../get-rule-content";
-import { RulePage } from "../../types";
 import { getFooter } from "../rule-content/frontmatter/get-footer";
-import { indent } from "../../utils/index";
 
 describe("getRuleContent", () => {
   const q = "```";
@@ -199,5 +199,164 @@ describe("getRuleContent", () => {
 
     `
     );
+  });
+
+  // Mapping to WCAG SCs adds a scs_tested key to the TF Markdown, which is
+  // somewhat annoying to handle in bulk. So they are not part of this test
+  // but are effectively tested as part of the previous one.
+  it("accept all possible non-WCAG mappings", () => {
+    const requirements = [
+      {
+        source: `aria12:state_property_processing:
+          title: ARIA 1.2, 8.6 State and Property Attribute Processing
+          forConformance: true
+          failed: not satisfied
+          passed: satisfied
+          inapplicable: satisfied`,
+        expected: outdent`
+        <ul class="act-requirements-list">
+          <li><details>
+            <summary><span>ARIA 1.2, 8.6 State and Property Attribute Processing</span></summary>
+            <ul>
+              <li><a href="https://www.w3.org/TR/wai-aria-1.2/#state_property_processing">Learn more about ARIA 1.2, 8.6 State and Property Attribute Processing</a></li>
+              <li><strong>Required for conformance</strong> to WAI-ARIA 1.2 author requirements.</li>
+              <li>Outcome mapping: <ul>
+                <li>Any <code>failed</code> outcomes: WAI-ARIA requirement is not satisfied</li>
+                <li>All <code>passed</code> outcomes: WAI-ARIA requirement is satisfied</li>
+                <li>An <code>inapplicable</code> outcome: WAI-ARIA requirement is satisfied</li>
+              </ul></li>
+            </ul>
+          </details></li>
+        </ul>`,
+        // {
+        //   source: `wcag-technique:ARIA5: # Using WAI-ARIA state and property attributes to expose the state of a user interface component
+        //     forConformance: false
+        //     failed: not satisfied
+        //     passed: further testing needed
+        //     inapplicable: further testing needed`,
+        //   expected: outdent``,
+        // },
+      },
+      // { source: `dpub-aria:`, expected: outdent`` },
+      // { source: `graphics-aria`, expected: outdent`` },
+      // { source: `html-aria:`, expected: outdent`` },
+      // { source: `using-aria:`, expected: outdent`` },
+      // { source: `wcag-text:`, expected: outdent`` },
+    ];
+
+    for (const requirement of requirements) {
+      const rulePage = parsePage(outdent`
+      ---
+      id: abc123
+      name: Hello world
+      rule_type: atomic
+      description: hello world
+      accessibility_requirements:
+        ${requirement.source}
+      input_aspects:
+        - DOM Tree
+      acknowledgments:
+        authors:
+          - Wilco Fiers
+      ---
+
+      [hello][], [w3c][]
+
+      ## Passed Example 1
+
+      ${q}html
+      <img alt="" />
+      ${q}
+
+      [hello]: #hello
+      [w3c]: https://w3.org 'W3C website'
+    `) as RulePage;
+
+      const taskforceMarkdown = getRuleContent(
+        { ...rulePage, filename: "abc123.md" },
+        glossary,
+
+        { matrix: true },
+        []
+      );
+
+      expect(taskforceMarkdown).toBe(
+        outdent`
+      ---
+      title: "Hello world"
+      permalink: /standards-guidelines/act/rules/abc123/
+      ref: /standards-guidelines/act/rules/abc123/
+      lang: en
+      github:
+        repository: w3c/wcag-act-rules
+        path: content/rules/abc123/index.md
+      feedbackmail: public-wcag-act@w3.org
+      footer: |
+      ${indent(getFooter(rulePage.frontmatter, false))}
+      proposed: false
+      rule_meta:
+        id: abc123
+        name: "Hello world"
+        rule_type: atomic
+        original_file: abc123.md
+        description: |
+          hello world
+        last_modified: ${moment().format("D MMMM YYYY")}
+      ---
+      
+      [hello][], [w3c][]
+
+      ## Accessibility Requirements Mapping
+
+      ${requirement.expected}
+
+      ## Input Aspects
+
+      The following aspects are required in using this rule.
+
+      - [DOM Tree](https://www.w3.org/TR/act-rules-aspects/#input-aspects-dom)
+
+      ## Test Cases
+      
+      ### Passed
+
+      #### Passed Example 1
+
+      <a class="example-link" title="Passed Example 1" target="_blank" href="https://w3.org/WAI/content-assets/wcag-act-rules/testcases/abc123/98a6b1fc6e5d43490f9c9a7cce9676487c94d2a3.html">Open in a new tab</a>
+
+      ${q}html
+      <img alt="" />
+      ${q}
+
+      ### Failed
+
+      _There are no failed examples._
+
+      ### Inapplicable
+
+      _There are no inapplicable examples._
+      
+      ## Glossary
+      
+      ### Hello {#hello}
+
+      Hello [world][]
+
+      ### Outcome {#outcome}
+
+      All good.
+
+      ### World {#world}
+
+      World of the [ACT-rules community][]
+      
+      [act-rules community]: https://act-rules.github.io
+      [hello]: #hello
+      [w3c]: https://w3.org 'W3C website'
+      [world]: #world
+
+    `
+      );
+    }
   });
 });

--- a/src/rule-transform/rule-content/__tests__/get-requirements-map.ts
+++ b/src/rule-transform/rule-content/__tests__/get-requirements-map.ts
@@ -108,8 +108,8 @@ describe("getRequirementsMap", () => {
         frontmatter: {
           ...defaultMatter,
           accessibility_requirements: {
-            "aria11:state_property_processing": {
-              title: "ARIA 1.1, 7.6 State and Property Attribute Processing",
+            "aria12:state_property_processing": {
+              title: "ARIA 1.2, 7.6 State and Property Attribute Processing",
               forConformance: true,
               ...scRequirement,
             },
@@ -117,7 +117,7 @@ describe("getRequirementsMap", () => {
         },
       });
       expect(reqMap).toContain(
-        "ARIA 1.1, 7.6 State and Property Attribute Processing"
+        "ARIA 1.2, 7.6 State and Property Attribute Processing"
       );
       expect(reqMap).toContain("Required for conformance");
       expect(reqMap).toContain("WAI-ARIA requirement is not satisfied");


### PR DESCRIPTION
Required for https://github.com/act-rules/act-rules.github.io/pull/2084

* Swapped mapping from ARIA 1.1 to ARIA 1.2, which is the one used in rules.
* Added possibility to map to ARIA in HTML.
* Add test for all used mappings.