### PR TITLE
fix(map-implementations): issue with mapping false positives on proposed changes to approved rules

### DIFF
--- a/src/map-implementation/procedure-sets/__tests__/find-procedure-set.test.ts
+++ b/src/map-implementation/procedure-sets/__tests__/find-procedure-set.test.ts
@@ -164,5 +164,35 @@ describe("findProcedureSet", () => {
       ]);
       expect(procedureSet).toHaveProperty("consistency", "partial");
     });
+
+    it("continues to filter proposed test cases on approved rules", () => {
+      const procedureSet = findProcedureSet([
+        {
+          ...procedureDefaults,
+          testResults: [
+            { ...correctFail, testcaseId: "fail1" },
+            { ...falseNegativeFail, testcaseId: "fail2" },
+            {
+              ...falsePositivePass,
+              testcaseId: "pass1",
+              testCaseApproved: false,
+            },
+          ],
+        },
+        {
+          ...procedureDefaults,
+          testResults: [
+            { ...falseNegativeFail, testcaseId: "fail1" },
+            { ...correctFail, testcaseId: "fail2" },
+            {
+              ...falsePositivePass,
+              testcaseId: "pass1",
+              testCaseApproved: false,
+            },
+          ],
+        },
+      ]);
+      expect(procedureSet).toHaveProperty("consistency", "complete");
+    });
   });
 });

--- a/src/map-implementation/procedure-sets/find-procedure-set.ts
+++ b/src/map-implementation/procedure-sets/find-procedure-set.ts
@@ -130,7 +130,7 @@ function combineTestResults(
   testResult: TestResult,
   procedureSet: ActProcedureMapping[]
 ): TestResult {
-  const { testcaseId, expected, testCaseName, testCaseUrl } = testResult;
+  const { testcaseId, expected } = testResult;
   const outcomes: ActualOutcome[] = [];
   const testcaseResults: TestResult[] = [];
   procedureSet.forEach((procedure) => {
@@ -143,9 +143,7 @@ function combineTestResults(
   testcaseResults.forEach((result) => outcomes.push(...result.outcomes));
   const automatic = testcaseResults.every(({ automatic }) => automatic);
   return {
-    testcaseId,
-    testCaseName,
-    testCaseUrl,
+    ...testResult,
     expected,
     outcomes,
     automatic,


### PR DESCRIPTION
Niche little edge case bug. When a check is partially consistent with the approved test cases of a rule, but inconsistent with proposed test cases the mapping would end up as inconsistent rather than partially consistent.

The problem occurs when trying to combine partially consistent checks. The `testCaseAccepted` property wasn't getting copied over when trying to combine them. Spreading `testResult` instead of copying individual properties prevents us from missing things.