### PR TITLE
Move `pre-commit` as a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "markdown-table": "2.0.0",
     "moment": "^2.29.1",
     "outdent": "^0.8.0",
-    "pre-commit": "^1.2.2",
     "rehype-stringify": "8.0.0",
     "remark-frontmatter": "^3.0.0",
     "remark-parse": "^9.0.0",
@@ -59,6 +58,7 @@
     "husky": "^7.0.1",
     "jest": "^29.5.0",
     "lint-staged": "^11.0.1",
+    "pre-commit": "^1.2.2",
     "prettier": "^2.3.2",
     "ts-jest": "^29.1.0"
   },


### PR DESCRIPTION
Being a regular dependency, `pre-commit` was installing itself in code using `act-tools`, thus somewhat forcing its use in these projects that may have different tooling and no use for it.

Moving it to a dev dependency instead should stop that and let dependants chose their tooling freely. This does mean that code that was, intentionally or not, relying an `act-tools` to run `pre-commit` must now add an explicit (dev) dependency to it.