### PR TITLE
feat: add frontmatter to rules.json file

### DIFF
--- a/src/rule-transform/__tests__/create-wcag-mapping.ts
+++ b/src/rule-transform/__tests__/create-wcag-mapping.ts
@@ -14,6 +14,11 @@ const mappingBase = {
   wcagTechniques: [],
   proposed: false,
   deprecated: false,
+  frontmatter: {
+    accessibility_requirements: null,
+    name: "Hello world",
+    id: "123abc",
+  },
 };
 
 function getRulePage(metadata = ""): RulePage {
@@ -78,6 +83,13 @@ describe("rule-transform", () => {
             permalink: "/standards-guidelines/act/rules/123abc/proposed/",
             successCriteria: ["non-text-content", "language-of-page"],
             proposed: true,
+            frontmatter: {
+              accessibility_requirements: {
+                "wcag20:1.1.1": { forConformance: true },
+                "wcag20:3.1.1": { forConformance: true },
+              },
+              ...rulePage.frontmatter,
+            },
           },
         ],
       });
@@ -106,6 +118,14 @@ describe("rule-transform", () => {
             successCriteria: ["non-text-content"],
             wcagTechniques: ["G123", "H42"],
             proposed: true,
+            frontmatter: {
+              accessibility_requirements: {
+                "wcag-technique:G123": { forConformance: false },
+                "wcag-technique:H42": { forConformance: false },
+                "wcag20:1.1.1": { forConformance: true },
+              },
+              ...rulePage.frontmatter,
+            },
           },
         ],
       });
@@ -261,6 +281,10 @@ describe("rule-transform", () => {
             title: "Hello world",
             permalink: "/standards-guidelines/act/rules/123abc/",
             deprecated: true,
+            frontmatter: {
+              deprecated: "This rule is deprecated.",
+              ...rulePage.frontmatter,
+            },
           },
         ],
       });

--- a/src/rule-transform/create-wcag-mapping.ts
+++ b/src/rule-transform/create-wcag-mapping.ts
@@ -10,6 +10,7 @@ export type ActWcagMap = {
   wcagTechniques: string[];
   proposed?: boolean;
   deprecated?: boolean;
+  frontmatter: RuleFrontMatter;
 };
 
 export type WcagMapping = {
@@ -61,6 +62,7 @@ export function updateWcagMapping(
     wcagTechniques,
     deprecated: typeof deprecated === "string",
     proposed,
+    frontmatter,
   });
   return wcagMapping;
 }


### PR DESCRIPTION
I just want full access to the rules' frontmatter for the website. RIght now there is no way to for example list a rule's secondary requirements.