### PR TITLE
Change 'test cases' to 'examples'

### DIFF
--- a/src/build-examples/__tests__/assets/sample-rule.md
+++ b/src/build-examples/__tests__/assets/sample-rule.md
@@ -3,7 +3,7 @@ id: abc123
 description: abc123 rule
 ---
 
-## Test Cases
+## Examples
 
 ### Passed
 

--- a/src/rule-transform/__tests__/get-rule-content.ts
+++ b/src/rule-transform/__tests__/get-rule-content.ts
@@ -141,7 +141,7 @@ describe("getRuleContent", () => {
 
       - [DOM Tree](https://www.w3.org/TR/act-rules-aspects/#input-aspects-dom)
 
-      ## Test Cases
+      ## Examples
       
       <details class="act-inline-assets" markdown="block">
       <summary><span>These Javascript and CSS files are used in several examples:</span></summary>
@@ -394,7 +394,7 @@ describe("getRuleContent", () => {
 
       - [DOM Tree](https://www.w3.org/TR/act-rules-aspects/#input-aspects-dom)
 
-      ## Test Cases
+      ## Examples
       
       ### Passed
 

--- a/src/rule-transform/rule-content/__tests__/get-examples-content.ts
+++ b/src/rule-transform/rule-content/__tests__/get-examples-content.ts
@@ -41,7 +41,7 @@ describe("rule-content", () => {
         assets: {},
       });
       expect(examples).toBe(outdent`
-        ## Test Cases
+        ## Examples
 
         ### Passed
 
@@ -79,7 +79,7 @@ describe("rule-content", () => {
         { noExampleLinks: true }
       );
       expect(examples).toBe(outdent`
-        ## Test Cases
+        ## Examples
 
         ### Passed
 
@@ -116,7 +116,7 @@ describe("rule-content", () => {
         assets,
       });
       expect(examples).toBe(outdent`
-        ## Test Cases
+        ## Examples
 
         <details class="act-inline-assets" markdown="block">
         <summary><span>This Javascript file is used in several examples:</span></summary>
@@ -171,7 +171,7 @@ describe("rule-content", () => {
         assets,
       });
       expect(examples).toBe(outdent`
-        ## Test Cases
+        ## Examples
 
         <details class="act-inline-assets" markdown="block">
         <summary><span>These Javascript files are used in several examples:</span></summary>
@@ -233,7 +233,7 @@ describe("rule-content", () => {
         assets,
       });
       expect(examples).toBe(outdent`
-        ## Test Cases
+        ## Examples
 
         <details class="act-inline-assets" markdown="block">
         <summary><span>These HTML, Javascript, and CSS files are used in several examples:</span></summary>
@@ -300,7 +300,7 @@ describe("rule-content", () => {
         assets,
       });
       expect(examples).toBe(outdent`
-        ## Test Cases
+        ## Examples
 
         <details class="act-inline-assets" markdown="block">
         <summary><span>These Javascript and CSS files are used in several examples:</span></summary>

--- a/src/rule-transform/rule-content/get-examples-content.ts
+++ b/src/rule-transform/rule-content/get-examples-content.ts
@@ -34,7 +34,7 @@ export function getExamplesContent(
   const assetsString = getAssetsString(assets);
 
   return joinStrings(
-    "## Test Cases",
+    "## Examples",
     assetsString,
     "### Passed",
     ...passed,


### PR DESCRIPTION
Relates to act-rules/act-rules.github.io#2352 and is needed here because the scripts overwrite the original string to `## Test Cases" anyway.