### PR TITLE
Add "composite" build option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "noImplicitAny": true,
     "resolveJsonModule": true,
     "baseUrl": "./",
-    "outDir": "dist"
+    "outDir": "dist",
+    "composite": true
   },
   "ts-node": {
     "files": true


### PR DESCRIPTION
I've had regularly checksum problems when trying to import this project as a packages from Github (e.g. `dependencies: { "act-tools": "github:act-rules/act-tools#main" }`, [Failing build](https://github.com/Siteimprove/alfa-act-r/actions/runs/18869764174/job/53845124931?pr=229)). The solution I've found is to instead use a git submodule to clone the repo, but that requires the submodule to have the TS `composite` option set.

I do not believe this will have any impact on the project. And it seems much more lightweight than going through the hassle of creating a full publication process for `act-tools`.