### PR TITLE
Add `rootDir` option to TS config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "resolveJsonModule": true,
     "baseUrl": "./",
     "outDir": "dist",
-    "composite": true
+    "composite": true,
+    "rootDir": "src"
   },
   "ts-node": {
     "files": true


### PR DESCRIPTION
With the recent adding of `composite`, the `rootDir` automatically became `.`, meaning that `src` was added back in the output structure (`/dist/src/…` instead of just `/dist/…`), resulting in breaking builds. Fixing this by explicitly setting `outDir`.