### PR TITLE
Include rules format info in generated footer 

### DIFF
--- a/src/rule-transform/rule-content/frontmatter/__tests__/get-footer.ts
+++ b/src/rule-transform/rule-content/frontmatter/__tests__/get-footer.ts
@@ -124,4 +124,21 @@ describe("getFooter", () => {
       expect(footer1).toContain(`approved and published by the ${agwg}`);
     });
   });
+
+  describe("rules_format", () => {
+    it("does not include rules_format paragraph when not provided", () => {
+      const footer = getFooter({});
+      expect(footer).not.toContain("This rule is compatible with");
+      expect(footer).not.toContain("ACT Rules Format");
+    });
+
+    it("includes rules_format paragraph with version number", () => {
+      const footer1 = getFooter({ rules_format: "1.0" });
+      expect(footer1).toContain("This rule is compatible with");
+      expect(footer1).toMatch(/ACT Rules Format \d\.\d/);
+      expect(footer1).toMatch(
+        /href="https:\/\/www\.w3\.org\/TR\/act-rules-format-\d\.\d\/"/
+      );
+    });
+  });
 });

--- a/src/rule-transform/rule-content/frontmatter/__tests__/get-footer.ts
+++ b/src/rule-transform/rule-content/frontmatter/__tests__/get-footer.ts
@@ -128,13 +128,13 @@ describe("getFooter", () => {
   describe("rules_format", () => {
     it("does not include rules_format paragraph when not provided", () => {
       const footer = getFooter({});
-      expect(footer).not.toContain("This rule is compatible with");
+      expect(footer).not.toContain("This rule conforms to");
       expect(footer).not.toContain("ACT Rules Format");
     });
 
     it("includes rules_format paragraph with version number", () => {
       const footer1 = getFooter({ rules_format: "1.0" });
-      expect(footer1).toContain("This rule is compatible with");
+      expect(footer1).toContain("This rule conforms to");
       expect(footer1).toMatch(/ACT Rules Format \d\.\d/);
       expect(footer1).toMatch(
         /href="https:\/\/www\.w3\.org\/TR\/act-rules-format-\d\.\d\/"/

--- a/src/rule-transform/rule-content/frontmatter/get-footer.ts
+++ b/src/rule-transform/rule-content/frontmatter/get-footer.ts
@@ -42,7 +42,7 @@ function getRulesFormatParagraph(rules_format?: string): string {
     return "";
   }
   return (
-    `<p>This rule is compatible with ` +
+    `<p>This rule conforms to ` +
     `<a href="https://www.w3.org/TR/act-rules-format-${rules_format}/">` +
     `ACT Rules Format ${rules_format}</a>.</p>\n`
   );

--- a/src/rule-transform/rule-content/frontmatter/get-footer.ts
+++ b/src/rule-transform/rule-content/frontmatter/get-footer.ts
@@ -6,10 +6,11 @@ import { markdownToHtml } from "../../../utils";
 type PartialFrontMatter = {
   id?: string;
   acknowledgments?: RuleFrontMatter["acknowledgments"];
+  rules_format?: string;
 };
 
 export function getFooter(
-  { acknowledgments, id }: PartialFrontMatter,
+  { acknowledgments, id, rules_format }: PartialFrontMatter,
   proposed?: boolean
 ): string {
   const date = moment().format("D MMMM YYYY");
@@ -17,6 +18,7 @@ export function getFooter(
     `<p><strong>Rule Identifier:</strong> ${id ?? "unknown"}</p>\n` +
     `<p><strong>Date:</strong> Updated ${date}</p>\n` +
     getAuthorParagraph(acknowledgments || {}) +
+    getRulesFormatParagraph(rules_format) +
     getSponsorParagraph(acknowledgments || {}, proposed) +
     getAssetsParagraph(acknowledgments || {})
   ).trim();
@@ -33,6 +35,17 @@ function getAuthorParagraph(acknowledgments: Record<string, string[]>): string {
     paragraph += `Previous Authors: ${getAuthors(previous_authors)}. `;
   }
   return paragraph + `${contributors}</p>\n`;
+}
+
+function getRulesFormatParagraph(rules_format?: string): string {
+  if (!rules_format) {
+    return "";
+  }
+  return (
+    `<p>This rule is compatible with ` +
+    `<a href="https://www.w3.org/TR/act-rules-format-${rules_format}/">` +
+    `ACT Rules Format ${rules_format}</a>.</p>\n`
+  );
 }
 
 function getSponsorParagraph(

--- a/src/rule-transform/rule-content/frontmatter/get-rule-meta.ts
+++ b/src/rule-transform/rule-content/frontmatter/get-rule-meta.ts
@@ -8,6 +8,10 @@ export function getRuleMeta(
   fileName: string
 ): string {
   const date = moment().format("D MMMM YYYY");
+  const rulesFormat = frontmatter.rules_format
+    ? `rules_format: ${frontmatter.rules_format}\n`
+    : "";
+  const scsTested = getSCsTested(frontmatter.accessibility_requirements || {});
   return outdent`
     id: ${frontmatter.id}
     name: "${frontmatter.name}"
@@ -16,7 +20,7 @@ export function getRuleMeta(
     description: |
       ${frontmatter.description.trim()}
     last_modified: ${date}
-    ${getSCsTested(frontmatter.accessibility_requirements || {})}
+    ${rulesFormat}${scsTested}
   `.trim();
 }
 

--- a/src/rule-transform/rule-content/frontmatter/get-rule-meta.ts
+++ b/src/rule-transform/rule-content/frontmatter/get-rule-meta.ts
@@ -8,10 +8,6 @@ export function getRuleMeta(
   fileName: string
 ): string {
   const date = moment().format("D MMMM YYYY");
-  const rulesFormat = frontmatter.rules_format
-    ? `rules_format: ${frontmatter.rules_format}\n`
-    : "";
-  const scsTested = getSCsTested(frontmatter.accessibility_requirements || {});
   return outdent`
     id: ${frontmatter.id}
     name: "${frontmatter.name}"
@@ -20,7 +16,7 @@ export function getRuleMeta(
     description: |
       ${frontmatter.description.trim()}
     last_modified: ${date}
-    ${rulesFormat}${scsTested}
+    ${getSCsTested(frontmatter.accessibility_requirements || {})}
   `.trim();
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export type RuleFrontMatterBase = {
   deprecated?: string;
   accessibility_requirements?: Record<string, AccessibilityRequirement>;
   acknowledgments?: Record<string, string[]>;
+  rules_format?: string;
 };
 
 export type AtomicRuleFrontmatter = RuleFrontMatterBase & {


### PR DESCRIPTION
This is needed to publish the [ACT Rules Format 1.1](https://www.w3.org/TR/act-rules-format-1.1/) as a W3C Recommendation, and is discussed at https://github.com/act-rules/act-rules.github.io/issues/2364