### PR TITLE
Fix typescript errors and consolidate dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@types/debug": "^4.1.12",
+    "@types/js-yaml": "^4.0.2",
+    "@types/jsonld": "^1.5.15",
+    "@types/markdown-table": "2.0.0",
     "axios": "^1.13.5",
     "commander": "^14.0.3",
     "debug": "^4.4.3",
@@ -41,11 +45,7 @@
   },
   "devDependencies": {
     "@fastify/pre-commit": "^2.2.1",
-    "@types/debug": "^4.1.12",
     "@types/jest": "^29.5.1",
-    "@types/js-yaml": "^4.0.2",
-    "@types/jsonld": "^1.5.15",
-    "@types/markdown-table": "2.0.0",
     "@types/node": "^25.2.0",
     "@types/unist": "^2.0.6",
     "@typescript-eslint/eslint-plugin": "^4.28.3",

--- a/src/implementations-update.ts
+++ b/src/implementations-update.ts
@@ -28,7 +28,7 @@ export async function cliProgram({
   const implementationMappings = await createImplementationMappings(
     implementationPath,
     outDir,
-    testCaseJson
+    testCaseJson,
   );
 
   for (const ruleId of getRuleIds(testCaseJson)) {
@@ -41,7 +41,7 @@ export async function cliProgram({
 async function createImplementationMappings(
   implementationPath: string,
   outDir: string,
-  testCasesJson: TestCaseJson
+  testCasesJson: TestCaseJson,
 ): Promise<ActImplementationReport[]> {
   const implementations = loadImplementations(implementationPath);
   const implementationMappings: ActImplementationReport[] = [];
@@ -54,7 +54,7 @@ async function createImplementationMappings(
       {
         name,
         vendor,
-      }
+      },
     );
     const filePath = path.resolve(outDir, `${filenameEscape(name)}.json`);
     console.log(`Writing file ${filePath}`);
@@ -69,8 +69,14 @@ function loadImplementations(implementationPath: string): Implementation[] {
   if (typeof yamlData !== "object" || yamlData === null) {
     return [];
   }
+  const yamlRecord = yamlData as Record<string, unknown>;
   const implementations: Implementation[] = [];
-  Object.entries(yamlData).forEach(([name, { vendor, report }]) => {
+  Object.entries(yamlRecord).forEach(([name, entry]) => {
+    if (typeof entry !== "object" || entry === null) {
+      console.warn(`Failed to load ${name}. Properties missing or invalid`);
+      return;
+    }
+    const { vendor, report } = entry as Record<string, unknown>;
     if (typeof vendor === "string" && typeof report === "string") {
       implementations.push({ name, vendor, report });
     } else {


### PR DESCRIPTION
Since I am trying to use act-tools as a dev dependency for building the WAI assets, it appears that there are typescript errors that prevent installing the package. The package-lock.json of act-rules.github.io pinned act-tools to an older versions and that is currently generating the wrong assets for the WAI website. Hopefully this resolves the typescript errors and will forwward act-tools to the latest version